### PR TITLE
Use ArrayIterator instead of Generator

### DIFF
--- a/src/Query/Conditions/Group.php
+++ b/src/Query/Conditions/Group.php
@@ -100,12 +100,10 @@ class Group implements \IteratorAggregate
     /**
      * Retrieve an external iterator.
      *
-     * @return Condition[]|\Generator
+     * @return \ArrayIterator|Condition[]
      */
     public function getIterator()
     {
-        foreach ($this->conditions as $i => $condition) {
-            yield $i => $condition;
-        }
+        return new \ArrayIterator($this->conditions);
     }
 }

--- a/src/Query/Select.php
+++ b/src/Query/Select.php
@@ -100,10 +100,10 @@ class Select extends SelectOrUnionAll
     /**
      * Retrieve an external iterator.
      *
-     * @return \Generator|Select[]
+     * @return \ArrayIterator|Select[]
      */
     public function getIterator()
     {
-        yield $this;
+        return new \ArrayIterator([$this]);
     }
 }

--- a/src/Query/UnionAll.php
+++ b/src/Query/UnionAll.php
@@ -56,11 +56,10 @@ class UnionAll extends SelectOrUnionAll implements \IteratorAggregate
     /**
      * Retrieve an external iterator.
      *
-     * @return \Generator|Select[]
+     * @return \ArrayIterator|Select[]
      */
     public function getIterator()
     {
-        yield $this->mainQuery;
-        yield $this->supportQuery;
+        return new \ArrayIterator([$this->mainQuery, $this->supportQuery]);
     }
 }

--- a/src/Query/Where.php
+++ b/src/Query/Where.php
@@ -100,12 +100,10 @@ class Where implements \IteratorAggregate
     /**
      * Retrieve an external iterator.
      *
-     * @return \Generator|Group[]
+     * @return \ArrayIterator|Group[]
      */
     public function getIterator()
     {
-        foreach ($this->groups as $i => $group) {
-            yield $i => $group;
-        }
+        return new \ArrayIterator($this->groups);
     }
 }


### PR DESCRIPTION
Generator is often used when it can reduce memory usage, however, it can't when iterating an existing array. So we do not need to use Generator.