### PR TITLE
Move Cursor interface location

### DIFF
--- a/src/ArrayCursor.php
+++ b/src/ArrayCursor.php
@@ -2,6 +2,8 @@
 
 namespace Lampager;
 
+use Lampager\Contracts\Cursor;
+
 /**
  * Default implementation for Cursor
  */

--- a/src/Contracts/Cursor.php
+++ b/src/Contracts/Cursor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lampager;
+namespace Lampager\Contracts;
 
 /**
  * Interface Cursor

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -2,6 +2,7 @@
 
 namespace Lampager;
 
+use Lampager\Contracts\Cursor;
 use Lampager\Query\Order;
 use Lampager\Query\Query;
 

--- a/src/Query/ConditionGroup.php
+++ b/src/Query/ConditionGroup.php
@@ -2,7 +2,7 @@
 
 namespace Lampager\Query;
 
-use Lampager\Cursor;
+use Lampager\Contracts\Cursor;
 use Lampager\ArrayCursor;
 
 /**

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -2,7 +2,7 @@
 
 namespace Lampager\Query;
 
-use Lampager\Cursor;
+use Lampager\Contracts\Cursor;
 use Lampager\ArrayCursor;
 
 /**

--- a/src/Query/SelectOrUnionAll.php
+++ b/src/Query/SelectOrUnionAll.php
@@ -2,7 +2,7 @@
 
 namespace Lampager\Query;
 
-use Lampager\Cursor;
+use Lampager\Contracts\Cursor;
 
 /**
  * Class SelectOrUnionAll


### PR DESCRIPTION
According to Laravel naming convention, all interfaces should be located in `Contracts`.
Of course still I know this project is not only for Laravel.