### PR TITLE
Move Query location

### DIFF
--- a/src/AbstractProcessor.php
+++ b/src/AbstractProcessor.php
@@ -3,7 +3,6 @@
 namespace Lampager;
 
 use Lampager\Contracts\Formatter;
-use Lampager\Query\Query;
 use Lampager\Query\UnionAll;
 
 /**

--- a/src/Concerns/HasProcessor.php
+++ b/src/Concerns/HasProcessor.php
@@ -4,7 +4,7 @@ namespace Lampager\Concerns;
 
 use Lampager\Contracts\Formatter;
 use Lampager\AbstractProcessor;
-use Lampager\Query\Query;
+use Lampager\Query;
 
 trait HasProcessor
 {

--- a/src/Contracts/Formatter.php
+++ b/src/Contracts/Formatter.php
@@ -2,7 +2,7 @@
 
 namespace Lampager\Contracts;
 
-use Lampager\Query\Query;
+use Lampager\Query;
 
 /**
  * Interface Formatter

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -4,7 +4,6 @@ namespace Lampager;
 
 use Lampager\Contracts\Cursor;
 use Lampager\Query\Order;
-use Lampager\Query\Query;
 
 /**
  * Class Paginator

--- a/src/Query.php
+++ b/src/Query.php
@@ -1,9 +1,14 @@
 <?php
 
-namespace Lampager\Query;
+namespace Lampager;
 
 use Lampager\Contracts\Cursor;
-use Lampager\ArrayCursor;
+use Lampager\Query\Direction;
+use Lampager\Query\Limit;
+use Lampager\Query\Order;
+use Lampager\Query\Select;
+use Lampager\Query\SelectOrUnionAll;
+use Lampager\Query\UnionAll;
 
 /**
  * Class Query

--- a/tests/CustomStubProcessor.php
+++ b/tests/CustomStubProcessor.php
@@ -3,7 +3,7 @@
 namespace Lampager\Tests;
 
 use Lampager\ArrayProcessor;
-use Lampager\Query\Query;
+use Lampager\Query;
 
 class CustomStubProcessor extends ArrayProcessor
 {

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -3,7 +3,7 @@
 namespace Lampager\Tests;
 
 use Lampager\ArrayProcessor;
-use Lampager\Query\Query;
+use Lampager\Query;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class FormatterTest extends BaseTestCase

--- a/tests/PaginatorTest.php
+++ b/tests/PaginatorTest.php
@@ -4,7 +4,7 @@ namespace Lampager\Tests;
 
 use Lampager\Paginator;
 use Lampager\Query\Order;
-use Lampager\Query\Query;
+use Lampager\Query;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class PaginatorTest extends BaseTestCase

--- a/tests/Query/QueryTest.php
+++ b/tests/Query/QueryTest.php
@@ -5,7 +5,7 @@ namespace Lampager\Tests\Query;
 use Lampager\ArrayCursor;
 use Lampager\Query\Direction;
 use Lampager\Query\Order;
-use Lampager\Query\Query;
+use Lampager\Query;
 use Lampager\Query\SelectOrUnionAll;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 


### PR DESCRIPTION
# Before

- **`use Lampager\Query\Query;`**
- `use Lampager\Query\Select;`
- `use Lampager\Query\Union;`

# After

- **`use Lampager\Query;`**
- `use Lampager\Query\Select;`
- `use Lampager\Query\Union;`

The latter looks natural.