### PR TITLE
Fix #10: Create Lampager\Contracts\Cursor::has(...$columns)

### DIFF
--- a/src/ArrayCursor.php
+++ b/src/ArrayCursor.php
@@ -29,7 +29,7 @@ class ArrayCursor implements Cursor
             return null;
         }
         foreach ($columns as $column) {
-            if (!isset($this->cursor[$column])) {
+            if (!array_key_exists($column, $this->cursor)) {
                 return false;
             }
         }

--- a/src/ArrayCursor.php
+++ b/src/ArrayCursor.php
@@ -23,9 +23,17 @@ class ArrayCursor implements Cursor
     /**
      * {@inheritdoc}
      */
-    public function has($column)
+    public function has(...$columns)
     {
-        return isset($this->cursor[$column]);
+        if (empty($this->cursor)) {
+            return null;
+        }
+        foreach ($columns as $column) {
+            if (!isset($this->cursor[$column])) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/src/ArrayCursor.php
+++ b/src/ArrayCursor.php
@@ -29,7 +29,7 @@ class ArrayCursor implements Cursor
             return null;
         }
         foreach ($columns as $column) {
-            if (!array_key_exists($column, $this->cursor)) {
+            if (!isset($this->cursor[$column])) {
                 return false;
             }
         }

--- a/src/Contracts/Cursor.php
+++ b/src/Contracts/Cursor.php
@@ -8,12 +8,11 @@ namespace Lampager\Contracts;
 interface Cursor
 {
     /**
-     * Return a value indicating whether the cursor has the column.
+     * Return a value indicating whether the cursor is non-empty and has the specified columns.
      *
-     * @param  string $column Column.
-     * @return bool
+     * @return null|bool null if the cursor is empty; true if the cursor has all the columns; otherwise false.
      */
-    public function has($column);
+    public function has(...$columns);
 
     /**
      * Return a cursor specified by the column.

--- a/src/Query/SelectOrUnionAll.php
+++ b/src/Query/SelectOrUnionAll.php
@@ -2,6 +2,7 @@
 
 namespace Lampager\Query;
 
+use Lampager\ArrayCursor;
 use Lampager\Contracts\Cursor;
 
 /**
@@ -20,8 +21,9 @@ abstract class SelectOrUnionAll implements \IteratorAggregate
      */
     public static function create(array $orders, $cursor, Limit $limit, Direction $direction, $exclusive, $seekable)
     {
+        $cursor = $cursor instanceof Cursor ? $cursor : new ArrayCursor($cursor);
         $mainQuery = new Select(
-            $cursor ? ConditionGroup::createMany($orders, $cursor, $direction, $exclusive) : [],
+            $cursor->has() ? ConditionGroup::createMany($orders, $cursor, $direction, $exclusive) : [],
             $direction->backward()
                 ? array_map(static function (Order $order) {
                     return $order->inverse();
@@ -30,7 +32,7 @@ abstract class SelectOrUnionAll implements \IteratorAggregate
             $limit
         );
 
-        if (!$cursor || !$seekable) {
+        if (!$cursor->has() || !$seekable) {
             // We don't need UNION ALL and support query when cursor parameters are empty,
             // or it does not need to be seekable.
             return $mainQuery;


### PR DESCRIPTION
The `Cursor::has` now accepts multiple arguments.

```php
<?php

interface Cursor
{
    /**
     * Return a value indicating whether the cursor is non-empty and has the specified columns.
     *
     * @return null|bool null if the cursor is empty; true if the cursor has all the columns; otherwise false.
     */
    public function has(...$columns);
}
```

`ArrayCursor` follows this change.