### PR TITLE
Run tests on PHP 7.4

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -16,7 +16,7 @@ build:
           - php-scrutinizer-run
 
   environment:
-    php: '7.3'
+    php: '7.4'
 
   dependencies:
     before:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
     - php: 7.1
     - php: 7.2
     - php: 7.3
+    - php: 7.4
 
 cache:
   directories:


### PR DESCRIPTION
PHP 7.4 has currently not yet been added to the Travis CI environments.