### PR TITLE
[Claude] Add PHP 8.5 to CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2, 8.3, 8.4]
+        php: [8.2, 8.3, 8.4, 8.5]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- Add PHP 8.5 to CI test matrix

## Test plan
- [ ] CI passes on PHP 8.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)